### PR TITLE
Adding yum config-manager and releasever settings to Dockerfile 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,11 @@ ARG KERNEL_VERSION
 ARG RT_KERNEL_VERSION
 ARG RHEL_VERSION
 
+RUN echo ${RHEL_VERSION} > /etc/yum/vars/releasever \
+    && yum config-manager --best --setopt=install_weak_deps=False --save
+
 # kernel packages needed to build drivers / kmods 
-RUN yum -y --best install \
+RUN yum -y install \
     kernel-core-${KERNEL_VERSION} \
     kernel-devel-${KERNEL_VERSION} \
     kernel-headers-${KERNEL_VERSION} \
@@ -14,7 +17,7 @@ RUN yum -y --best install \
     && yum clean all
 
 # real-time kernel packages
-RUN yum -y --best install \
+RUN yum -y install \
     kernel-rt-core-${RT_KERNEL_VERSION} \
     kernel-rt-devel-${RT_KERNEL_VERSION} \
     kernel-rt-modules-${RT_KERNEL_VERSION} \
@@ -22,11 +25,11 @@ RUN yum -y --best install \
     && yum clean all
 
 # Additional packages that are mandatory for driver-containers
-RUN yum -y --best install elfutils-libelf-devel kmod binutils kabi-dw kernel-abi-whitelists \
+RUN yum -y install elfutils-libelf-devel kmod binutils kabi-dw kernel-abi-whitelists \
     && yum clean all
 
 # Packages needed to build kmods-via-containers and likely needed for driver-containers
-RUN yum -y --best install git make \
+RUN yum -y install git make \
     && yum clean all
 
 # Add and build kmods-via-containers


### PR DESCRIPTION
Added
```
RUN echo ${RHEL_VERSION} > /etc/yum/vars/releasever \
    && yum config-manager --best --setopt=install_weak_deps=False --save
```

So that we don't need to add 
```
--releasever=${RELEASEVER} --setopt=install_weak_deps=False --best
```
to yum install commands in the driver container builds based on driver-toolkit.

/cc @zvonkok 