### PR TITLE
Optionally set KERNEL_VERSION and RT_KERNEL_VERSION

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,28 @@
 FROM registry.access.redhat.com/ubi8/ubi 
 
+ARG KERNEL_VERSION=''
+ARG RT_KERNEL_VERSION=''
+ARG RHEL_VERSION=''
+
 RUN echo ${RHEL_VERSION} > /etc/yum/vars/releasever \
     && yum config-manager --best --setopt=install_weak_deps=False --save
 
 # kernel packages needed to build drivers / kmods 
 RUN yum -y install \
-    kernel-core \
-    kernel-devel \
-    kernel-headers \
-    kernel-modules \
-    kernel-modules-extra \
+    kernel-core${KERNEL_VERSION:+-}${KERNEL_VERSION} \
+    kernel-devel${KERNEL_VERSION:+-}${KERNEL_VERSION} \
+    kernel-headers${KERNEL_VERSION:+-}${KERNEL_VERSION} \
+    kernel-modules${KERNEL_VERSION:+-}${KERNEL_VERSION} \
+    kernel-modules-extra${KERNEL_VERSION:+-}${KERNEL_VERSION} \
     && yum clean all
 
 # real-time kernel packages
 RUN if [ $(arch) = x86_64 ]; then \
     yum -y install \
-    kernel-rt-core \
-    kernel-rt-devel \
-    kernel-rt-modules \
-    kernel-rt-modules-extra \
+    kernel-rt-core${RT_KERNEL_VERSION:+-}${RT_KERNEL_VERSION} \
+    kernel-rt-devel${RT_KERNEL_VERSION:+-}${RT_KERNEL_VERSION} \
+    kernel-rt-modules${RT_KERNEL_VERSION:+-}${RT_KERNEL_VERSION} \
+    kernel-rt-modules-extra${RT_KERNEL_VERSION:+-}${RT_KERNEL_VERSION} \
     && yum clean all ; fi
 
 # Additional packages that are mandatory for driver-containers


### PR DESCRIPTION
Setting an empty default value for `ARG` entries eliminates the need of the following downstream modifications:
```
    - action: replace
      match: 'ARG KERNEL_VERSION'
      replacement: ''

    - action: replace
      match: 'ARG RT_KERNEL_VERSION'
      replacement: ''

    - action: replace
      match: 'ARG RHEL_VERSION'
      replacement: ''
```
https://github.com/openshift/ocp-build-data/blob/6861686494e12d5cbecde7d67f5ba01f4afe6323/images/driver-toolkit.yml#L10-L20

Using this bash's parameter expansion `${VAR:+-}` appends a `-` only if `$VAR` is not empty, eliminating the following downstream modifications:
```
    - action: replace
      match: '-${KERNEL_VERSION}'
      replacement: ''

    - action: replace
      match: '-${RT_KERNEL_VERSION}'
      replacement: ''
```
https://github.com/openshift/ocp-build-data/blob/6861686494e12d5cbecde7d67f5ba01f4afe6323/images/driver-toolkit.yml#L22-L28

---

This way, ART builds will use basically the same `Dockerfile` as upstream, and we'd use those replacement modifications only when we want to explicitly pin a version:
```
content:
  source:
    modifications:
    - action: replace
      match: "ARG KERNEL_VERSION=''"
      replacement: "ARG KERNEL_VERSION='1.2.3'"

    - action: replace
      match: "ARG RT_KERNEL_VERSION=''"
      replacement: "ARG RT_KERNEL_VERSION='1.2.3'"
```