### PR TITLE
Bug 1945602: [release-4.6] Optionally set KERNEL_VERSION and RT_KERNEL_VERSION

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/4.8:base
+FROM registry.ci.openshift.org/ocp/4.6:base
 
 ARG KERNEL_VERSION=''
 ARG RT_KERNEL_VERSION=''

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi
+FROM registry.access.redhat.com/ubi8/ubi 
 
 ARG KERNEL_VERSION=''
 ARG RT_KERNEL_VERSION=''

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi 
+FROM registry.ci.openshift.org/ocp/4.6:base 
 
 ARG KERNEL_VERSION=''
 ARG RT_KERNEL_VERSION=''

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/4.6:base
+FROM registry.access.redhat.com/ubi8/ubi
 
 ARG KERNEL_VERSION=''
 ARG RT_KERNEL_VERSION=''


### PR DESCRIPTION
Setting an empty default value for `ARG` entries eliminates the need of the following downstream modifications:
```
    - action: replace
      match: 'ARG KERNEL_VERSION'
      replacement: ''

    - action: replace
      match: 'ARG RT_KERNEL_VERSION'
      replacement: ''

    - action: replace
      match: 'ARG RHEL_VERSION'
      replacement: ''
```
https://github.com/openshift/ocp-build-data/blob/6861686494e12d5cbecde7d67f5ba01f4afe6323/images/driver-toolkit.yml#L10-L20

Using this bash's parameter expansion `${VAR:+-}` appends a `-` only if `$VAR` is not empty, eliminating the following downstream modifications:
```
    - action: replace
      match: '-${KERNEL_VERSION}'
      replacement: ''

    - action: replace
      match: '-${RT_KERNEL_VERSION}'
      replacement: ''
```
https://github.com/openshift/ocp-build-data/blob/6861686494e12d5cbecde7d67f5ba01f4afe6323/images/driver-toolkit.yml#L22-L28

---

This way, ART builds will use basically the same `Dockerfile` as upstream, and we'd use those replacement modifications only when we want to explicitly pin a version:
```
content:
  source:
    modifications:
    - action: replace
      match: "ARG KERNEL_VERSION=''"
      replacement: "ARG KERNEL_VERSION='1.2.3'"

    - action: replace
      match: "ARG RT_KERNEL_VERSION=''"
      replacement: "ARG RT_KERNEL_VERSION='1.2.3'"
```