### PR TITLE
Bug 1959190: Add LABEL io.openshift.release.operator=true for addition to payload

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,4 +42,5 @@ RUN make install DESTDIR=/usr/local CONFDIR=/etc/
 
 LABEL io.k8s.description="driver-toolkit is a container with the kernel packages necessary for building driver containers for deploying kernel modules/drivers on OpenShift" \
       name="driver-toolkit" \
+      io.openshift.release.operator=true \
       version="0.1"


### PR DESCRIPTION
The driver-toolkit should be shipped as part of the release payload, however the necessary label 

`LABEL io.openshift.release.operator=true`

is missing from the Dockerfile.

Relevant docs: https://docs.ci.openshift.org/docs/how-tos/onboarding-a-new-component/#product-builds-and-becoming-part-of-an-openshift-release-image


ART is able to patch this label in on their side, but in order for the driver-toolkit to also be a part of the ci release images, this fix needs to be added and back-ported.
