### PR TITLE
[release-4.8] Bug 1961656: Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,6 @@ LABEL io.k8s.description="driver-toolkit is a container with the kernel packages
       io.openshift.release.operator=true \
       version="0.1"
 
-ENV INSTALLED_KERNEL=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}"  kernel-core)
-ENV INSTALLED_RT_KERNEL=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}"  kernel-rt-core)
-
-# Last layer for mapping the driver-toolkit to the corresponding Node     
-RUN  echo "{ \"KERNEL_VERSION\": \"${KERNEL_VERSION:-${INSTALLED_KERNEL}}\", \"RT_KERNEL_VERSION\": \"${RT_KERNEL_VERSION:-${INSTALLED_RT_KERNEL}}\", \"RHEL_VERSION\": \"${RHEL_VERSION}\" }" > /etc/driver-toolkit-release.json
+RUN export INSTALLED_KERNEL=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}"  kernel-core); \
+    export INSTALLED_RT_KERNEL=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}"  kernel-rt-core); \
+    echo "{ \"KERNEL_VERSION\": \"${KERNEL_VERSION:-${INSTALLED_KERNEL}}\", \"RT_KERNEL_VERSION\": \"${RT_KERNEL_VERSION:-${INSTALLED_RT_KERNEL}}\", \"RHEL_VERSION\": \"${RHEL_VERSION}\" }" > /etc/driver-toolkit-release.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,5 +45,8 @@ LABEL io.k8s.description="driver-toolkit is a container with the kernel packages
       io.openshift.release.operator=true \
       version="0.1"
 
+ENV INSTALLED_KERNEL=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}"  kernel-core)
+ENV INSTALLED_RT_KERNEL=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}"  kernel-rt-core)
+
 # Last layer for mapping the driver-toolkit to the corresponding Node     
-RUN  echo "{ \"KERNEL_VERSION\": \"${KERNEL_VERSION:-$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}"  kernel-core)}\", \"RT_KERNEL_VERSION\": \"${RT_KERNEL_VERSION:-$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}"  kernel-rt-core)}\", \"RHEL_VERSION\": \"${RHEL_VERSION}\" }" > /etc/driver-toolkit-release.json
+RUN  echo "{ \"KERNEL_VERSION\": \"${KERNEL_VERSION:-${INSTALLED_KERNEL}}\", \"RT_KERNEL_VERSION\": \"${RT_KERNEL_VERSION:-${INSTALLED_RT_KERNEL}}\", \"RHEL_VERSION\": \"${RHEL_VERSION}\" }" > /etc/driver-toolkit-release.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ LABEL io.k8s.description="driver-toolkit is a container with the kernel packages
       io.openshift.release.operator=true \
       version="0.1"
 
+# Last layer for metadata for mapping the driver-toolkit to a specific kernel version
 RUN export INSTALLED_KERNEL=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}"  kernel-core); \
     export INSTALLED_RT_KERNEL=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}"  kernel-rt-core); \
     echo "{ \"KERNEL_VERSION\": \"${KERNEL_VERSION:-${INSTALLED_KERNEL}}\", \"RT_KERNEL_VERSION\": \"${RT_KERNEL_VERSION:-${INSTALLED_RT_KERNEL}}\", \"RHEL_VERSION\": \"${RHEL_VERSION}\" }" > /etc/driver-toolkit-release.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,4 +46,4 @@ LABEL io.k8s.description="driver-toolkit is a container with the kernel packages
       version="0.1"
 
 # Last layer for mapping the driver-toolkit to the corresponding Node     
-RUN  echo "{ \"KERNEL_VERSION\": \"${KERNEL_VERSION}\", \"RT_KERNEL_VERSION\": \"${RT_KERNEL_VERSION}\", \"RHEL_VERSION\": \"${RHEL_VERSION}\" }" > /etc/driver-toolkit-release.json
+RUN  echo "{ \"KERNEL_VERSION\": \"${KERNEL_VERSION:-$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}"  kernel-core)}\", \"RT_KERNEL_VERSION\": \"${RT_KERNEL_VERSION:-$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}"  kernel-rt-core)}\", \"RHEL_VERSION\": \"${RHEL_VERSION}\" }" > /etc/driver-toolkit-release.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,3 +44,6 @@ LABEL io.k8s.description="driver-toolkit is a container with the kernel packages
       name="driver-toolkit" \
       io.openshift.release.operator=true \
       version="0.1"
+
+# Last layer for mapping the driver-toolkit to the corresponding Node     
+RUN  echo "{ \"KERNEL_VERSION\": \"${KERNEL_VERSION}\", \"RT_KERNEL_VERSION\": \"${RT_KERNEL_VERSION}\", \"RHEL_VERSION\": \"${RHEL_VERSION}\" }" > /etc/driver-toolkit-release.json


### PR DESCRIPTION
Adding the last layer for mapping of the driver-toolkit to the correspoinding Node, SRO will pull the last layer of the release-payload, get the driver-toolkit URL and use the last layer of the driver-toolkit for mapping the right kernel versions.