### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,11 @@ RUN if [ $(arch) = x86_64 ]; then \
 # Additional packages that are mandatory for driver-containers
 RUN yum -y install elfutils-libelf-devel kmod binutils kabi-dw kernel-abi-whitelists \
     && yum clean all
-
+    
+# Additional packages that are needed for a subset (e.g DPDK) of driver-containers
+RUN yum -y install xz diffutils \
+    && yum clean all
+    
 # Packages needed to build kmods-via-containers and likely needed for driver-containers
 RUN yum -y install git make \
     && yum clean all


### PR DESCRIPTION
OOT Kernel modules distrbuted as tar.xz (like for dpdk kni kmods) requires the xz for tar to uncompress it. The same package requires the cmp command (which is part of diffutils) to compile the kmod.