### PR TITLE
Requirements for authenticating kernel modules with X.509 keys

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,10 @@ RUN yum -y install xz diffutils \
 RUN yum -y install git make \
     && yum clean all
 
+# Packages needed to sign and run externally build kernel modules
+RUN yum -y install openssl mokutil keyutils \
+    && yum clean all
+
 # Add and build kmods-via-containers
 COPY kmods-via-containers /tmp/kmods-via-containers
 


### PR DESCRIPTION
In RHEL 8, when a kernel module is loaded, the kernel checks the signature of the module against the public X.509 keys from the kernel system keyring (.builtin_trusted_keys) and the kernel platform keyring (.platform). The .platform keyring contains keys from third-party platform providers and custom public keys. The keys from the kernel system .blacklist keyring are excluded from verification.