### PR TITLE
Install gcc in driver-toolkit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,14 @@ RUN if [ $(arch) = x86_64 ]; then \
 RUN yum -y install elfutils-libelf-devel kmod binutils kabi-dw kernel-abi-whitelists \
     && yum clean all
     
+# Find and install the GCC version used to compile the kernel
+RUN export INSTALLED_KERNEL=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}"  kernel-core) \
+&& /usr/src/kernels/${INSTALLED_KERNEL}/scripts/extract-vmlinux /lib/modules/${INSTALLED_KERNEL}/vmlinuz | strings | grep -E '^Linux version'  > /tmp/kernel_info \
+&& GCC_VERSION=$(cat /tmp/kernel_info | grep -Eo "gcc version ([0-9\.]+)" | grep -Eo "([0-9\.]+)") \
+&& yum -y install gcc-${GCC_VERSION}
+
 # Additional packages that are needed for a subset (e.g DPDK) of driver-containers
-RUN yum -y install gcc xz diffutils \
+RUN yum -y install xz diffutils \
     && yum clean all
     
 # Packages needed to build kmods-via-containers and likely needed for driver-containers

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN yum -y install elfutils-libelf-devel kmod binutils kabi-dw kernel-abi-whitel
     && yum clean all
     
 # Additional packages that are needed for a subset (e.g DPDK) of driver-containers
-RUN yum -y install xz diffutils \
+RUN yum -y install gcc xz diffutils \
     && yum clean all
     
 # Packages needed to build kmods-via-containers and likely needed for driver-containers


### PR DESCRIPTION
For some driver container builds (e.g. NVIDIA driver) we need the gcc version which was used to build the kernel.

/cc @kpouget 
/cc @zvonkok 