### PR TITLE
Rewrite architecture check for mokutil installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,8 @@ RUN yum -y install git make \
     && yum clean all
 
 # Packages needed to sign and run externally build kernel modules
-RUN ARCH_DEP_PKGS=$(case $(arch) in x86_64|aarch64) echo -n mokutil ;; esac) \
+RUN if [[ $(arch) == "x86_64" || $(arch) == "aarch64" ]]; then \
+    ARCH_DEP_PKGS="mokutil"; fi \
     && yum -y install openssl keyutils $ARCH_DEP_PKGS \
     && yum clean all
 


### PR DESCRIPTION
Docker reconciliation is failing in the ART pipelines due to the current $(arch) check. A suggestion to fix it was to rewrite these lines to be more similar to the previous $(arch) check.