### PR TITLE
Rearrange architecture check 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN yum -y install git make \
     && yum clean all
 
 # Packages needed to sign and run externally build kernel modules
-RUN if [[ $(arch) == "x86_64" || $(arch) == "aarch64" ]]; then \
+RUN if [ $(arch) == "x86_64" ] || [ $(arch) == "aarch64" ]; then \
     ARCH_DEP_PKGS="mokutil"; fi \
     && yum -y install openssl keyutils $ARCH_DEP_PKGS \
     && yum clean all


### PR DESCRIPTION
The last PR to fix this was still not working in the ART pipeline. I assume this is because of the use of `[[ ... || ... ]]` instead of the POSIX compatible / sh compatible `[ ... ] || [ ... ]`