### PR TITLE
Fix GCC install on non-x86 and add yum clean all

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,10 +30,15 @@ RUN yum -y install elfutils-libelf-devel kmod binutils kabi-dw kernel-abi-whitel
     && yum clean all
     
 # Find and install the GCC version used to compile the kernel
-RUN export INSTALLED_KERNEL=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}"  kernel-core) \
-&& /usr/src/kernels/${INSTALLED_KERNEL}/scripts/extract-vmlinux /lib/modules/${INSTALLED_KERNEL}/vmlinuz | strings | grep -E '^Linux version'  > /tmp/kernel_info \
+# If it cannot be found (fails on some architecutres), install the default gcc
+RUN curl -fsSL -o /usr/local/bin/extract-vmlinux https://raw.githubusercontent.com/torvalds/linux/master/scripts/extract-vmlinux \
+&& chmod +x /usr/local/bin/extract-vmlinux \
+&& export INSTALLED_KERNEL=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}"  kernel-core) \
+&& /usr/local/bin/extract-vmlinux /lib/modules/${INSTALLED_KERNEL}/vmlinuz | strings | grep -E '^Linux version'  > /tmp/kernel_info \
 && GCC_VERSION=$(cat /tmp/kernel_info | grep -Eo "gcc version ([0-9\.]+)" | grep -Eo "([0-9\.]+)") \
-&& yum -y install gcc-${GCC_VERSION}
+&& yum -y install gcc-${GCC_VERSION} \
+|| yum -y install gcc && \
+yum clean all
 
 # Additional packages that are needed for a subset (e.g DPDK) of driver-containers
 RUN yum -y install xz diffutils \


### PR DESCRIPTION
Image builds for the driver-toolkit are currently failing on aarch64 and s390x. Specifically the extract-vmlinux script is failing in the gcc install step.

This PR will change two things about the gcc install:
 - In the case that we are unable to check vmlinux for which gcc version was used to compile the kernel, we should install gcc without a specified version.
 - We should also be running yum clean all in this step. 