### PR TITLE
 [release-4.8] Bug 1972676: Requirements for authenticating kernel modules with X.509 keys 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,10 @@ RUN yum -y install elfutils-libelf-devel kmod binutils kabi-dw kernel-abi-whitel
 RUN yum -y install git make \
     && yum clean all
 
+# Packages needed to sign and run externally build kernel modules
+RUN yum -y install openssl mokutil keyutils \
+    && yum clean all
+
 # Add and build kmods-via-containers
 COPY kmods-via-containers /tmp/kmods-via-containers
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,8 @@ RUN yum -y install git make \
     && yum clean all
 
 # Packages needed to sign and run externally build kernel modules
-RUN yum -y install openssl mokutil keyutils \
+RUN ARCH_DEP_PKGS=$(case $(arch) in x86_64|aarch64) echo -n mokutil ;; esac) \
+    && yum -y install openssl keyutils $ARCH_DEP_PKGS \
     && yum clean all
 
 # Add and build kmods-via-containers

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN yum -y install git make \
     && yum clean all
 
 # Packages needed to sign and run externally build kernel modules
-RUN if [[ $(arch) == "x86_64" || $(arch) == "aarch64" ]]; then \
+RUN if [ $(arch) == "x86_64" ] || [ $(arch) == "aarch64" ]; then \
     ARCH_DEP_PKGS="mokutil"; fi \
     && yum -y install openssl keyutils $ARCH_DEP_PKGS \
     && yum clean all

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,8 @@ RUN yum -y install git make \
     && yum clean all
 
 # Packages needed to sign and run externally build kernel modules
-RUN ARCH_DEP_PKGS=$(case $(arch) in x86_64|aarch64) echo -n mokutil ;; esac) \
+RUN if [[ $(arch) == "x86_64" || $(arch) == "aarch64" ]]; then \
+    ARCH_DEP_PKGS="mokutil"; fi \
     && yum -y install openssl keyutils $ARCH_DEP_PKGS \
     && yum clean all
 


### PR DESCRIPTION
This is a manual cherry-pick of the commits related to installing openssl, keyutils, and (architecture dependent) mokutil

/assign @zvonkok 