### PR TITLE
[release 4.8] Bug 1974447: Cherry pick gcc to release 4.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,12 @@ RUN yum -y install elfutils-libelf-devel kmod binutils kabi-dw kernel-abi-whitel
 RUN yum -y install xz diffutils \
     && yum clean all
     
+# Find and install the GCC version used to compile the kernel
+RUN export INSTALLED_KERNEL=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}"  kernel-core) \
+&& /usr/src/kernels/${INSTALLED_KERNEL}/scripts/extract-vmlinux /lib/modules/${INSTALLED_KERNEL}/vmlinuz | strings | grep -E '^Linux version'  > /tmp/kernel_info \
+&& GCC_VERSION=$(cat /tmp/kernel_info | grep -Eo "gcc version ([0-9\.]+)" | grep -Eo "([0-9\.]+)") \
+&& yum -y install gcc-${GCC_VERSION}
+
 # Packages needed to build kmods-via-containers and likely needed for driver-containers
 RUN yum -y install git make \
     && yum clean all

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,10 +34,15 @@ RUN yum -y install xz diffutils \
     && yum clean all
     
 # Find and install the GCC version used to compile the kernel
-RUN export INSTALLED_KERNEL=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}"  kernel-core) \
-&& /usr/src/kernels/${INSTALLED_KERNEL}/scripts/extract-vmlinux /lib/modules/${INSTALLED_KERNEL}/vmlinuz | strings | grep -E '^Linux version'  > /tmp/kernel_info \
+# If it cannot be found (fails on some architecutres), install the default gcc
+RUN curl -fsSL -o /usr/local/bin/extract-vmlinux https://raw.githubusercontent.com/torvalds/linux/master/scripts/extract-vmlinux \
+&& chmod +x /usr/local/bin/extract-vmlinux \
+&& export INSTALLED_KERNEL=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}"  kernel-core) \
+&& /usr/local/bin/extract-vmlinux /lib/modules/${INSTALLED_KERNEL}/vmlinuz | strings | grep -E '^Linux version'  > /tmp/kernel_info \
 && GCC_VERSION=$(cat /tmp/kernel_info | grep -Eo "gcc version ([0-9\.]+)" | grep -Eo "([0-9\.]+)") \
-&& yum -y install gcc-${GCC_VERSION}
+&& yum -y install gcc-${GCC_VERSION} \
+|| yum -y install gcc && \
+yum clean all
 
 # Packages needed to build kmods-via-containers and likely needed for driver-containers
 RUN yum -y install git make \


### PR DESCRIPTION
The NVIDIA GPU operator currently requires entitlements to build the driver container, but the driver-toolkit could be used to prevent this. The problem is that the driver-toolkit is currently missing the gcc package needed for this driver-container. This is needed for RHODS.

The fix is to install gcc, specifically the version used to compile the kernel when available.
