### PR TITLE
Bug 1977972: /etc/driver-toolkit-release.json kernel version match rpm -q output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,4 +69,4 @@ LABEL io.k8s.description="driver-toolkit is a container with the kernel packages
 # Last layer for metadata for mapping the driver-toolkit to a specific kernel version
 RUN export INSTALLED_KERNEL=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}"  kernel-core); \
     export INSTALLED_RT_KERNEL=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}"  kernel-rt-core); \
-    echo "{ \"KERNEL_VERSION\": \"${KERNEL_VERSION:-${INSTALLED_KERNEL}}\", \"RT_KERNEL_VERSION\": \"${RT_KERNEL_VERSION:-${INSTALLED_RT_KERNEL}}\", \"RHEL_VERSION\": \"${RHEL_VERSION}\" }" > /etc/driver-toolkit-release.json
+    echo "{ \"KERNEL_VERSION\": \"${INSTALLED_KERNEL}\", \"RT_KERNEL_VERSION\": \"${INSTALLED_RT_KERNEL}\", \"RHEL_VERSION\": \"${RHEL_VERSION}\" }" > /etc/driver-toolkit-release.json


### PR DESCRIPTION
In versions of OCP where ART is specifying the kernel version as an argument to the driver-toolkit image build, the KERNEL_VERSION and RT_KERNEL_VERSION in /etc/driver-toolkit-release.json is missing the architecture at the end. Currently this is seen when comparing between DTK builds in 4.7 and 4.8

This results in unneeded inconsistencies between OCP versions, and means in some cases the kernel versions do not match with the node labels from NFD.
