### PR TITLE
Bug 1979738: Remove curl of extract-vmlinux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,10 +31,8 @@ RUN yum -y install elfutils-libelf-devel kmod binutils kabi-dw kernel-abi-whitel
     
 # Find and install the GCC version used to compile the kernel
 # If it cannot be found (fails on some architecutres), install the default gcc
-RUN curl -fsSL -o /usr/local/bin/extract-vmlinux https://raw.githubusercontent.com/torvalds/linux/master/scripts/extract-vmlinux \
-&& chmod +x /usr/local/bin/extract-vmlinux \
-&& export INSTALLED_KERNEL=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}"  kernel-core) \
-&& /usr/local/bin/extract-vmlinux /lib/modules/${INSTALLED_KERNEL}/vmlinuz | strings | grep -E '^Linux version'  > /tmp/kernel_info \
+RUN export INSTALLED_KERNEL=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}"  kernel-core) \
+&& /usr/src/kernels/${INSTALLED_KERNEL}/scripts/extract-vmlinux /lib/modules/${INSTALLED_KERNEL}/vmlinuz | strings | grep -E '^Linux version'  > /tmp/kernel_info \
 && GCC_VERSION=$(cat /tmp/kernel_info | grep -Eo "gcc version ([0-9\.]+)" | grep -Eo "([0-9\.]+)") \
 && yum -y install gcc-${GCC_VERSION} \
 || yum -y install gcc && \


### PR DESCRIPTION
Currently, the Dockerfile tries to curl the extract-vmlinux script, which does not work in the ART build environment. This script is available as part of the kernel packages already installed in the location /usr/src/kernels/${INSTALLED_KERNEL}/scripts/extract-vmlinux, on x86 and aarch64.

In the other architectures, we can just install whichever gcc version is available by default in the ART builds.

This is needed in order for force the driver-toolkit to install the specific gcc version which was used to compile the kernel in the driver-toolkit.
