### PR TITLE
(reimplement) Add imagestream for driver-toolkit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,8 @@ WORKDIR /tmp/kmods-via-containers
 
 RUN make install DESTDIR=/usr/local CONFDIR=/etc/
 
+COPY manifests /manifests
+
 LABEL io.k8s.description="driver-toolkit is a container with the kernel packages necessary for building driver containers for deploying kernel modules/drivers on OpenShift" \
       name="driver-toolkit" \
       io.openshift.release.operator=true \

--- a/manifests/01-openshift-imagestream.yaml
+++ b/manifests/01-openshift-imagestream.yaml
@@ -1,0 +1,23 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  namespace: openshift
+  name: driver-toolkit
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+spec:
+  tags:
+  - name: latest
+    importPolicy:
+      scheduled: true
+    from:
+      kind: DockerImage
+      name: example.com/image-reference-placeholder:driver-toolkit
+  - name: 0.0.1-snapshot-machine-os 
+    importPolicy:
+      scheduled: true
+    from:
+      kind: DockerImage
+      name: example.com/image-reference-placeholder:driver-toolkit

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -1,0 +1,12 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+spec:
+  tags:
+  - name: driver-toolkit
+    from:
+      kind: DockerImage
+      name: example.com/image-reference-placeholder:driver-toolkit
+  - name: machine-os-content
+    from:
+      kind: DockerImage
+      name: registry.svc.ci.openshift.org/openshift:machine-os-content


### PR DESCRIPTION
Reverts openshift/driver-toolkit#61, which reverted #60. It can now be un-reverted because the following PR has merged openshift/kubernetes#963. 

From the original PR:

> This PR adds a manifests/ directory, and a manifest for an imagestream.
> 
> The imagestream contains a latest tag, and a tag for the RHCOS version corresponding to a release.
> The string 0.0.1-snapshot-machine-os will be substituted with the RHCOS version in the manifest. The substitution will happen when oc adm release new ... is run, and the rhcos version is scraped from the machine-os-content.
> 
> See the oc code for information on how the substitution works. https://github.com/openshift/oc/blob/5d8dfa1c2e8e7469d69d76f21e0a166a0de8663b/pkg/cli/admin/release/image_mapper.go#L328-L334
> 
> Signed-off-by: David Gray dagray@redhat.com

/cc @kpouget 