### PR TITLE
Add script to test driver-toolkit ImageStream and image contents

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,6 @@ PWD              ?= $(shell pwd)
 
 verify: 
 	cat ./Dockerfile
+
+test-e2e:
+	./test/e2e

--- a/test/e2e
+++ b/test/e2e
@@ -1,0 +1,165 @@
+#! /bin/bash
+
+set -eux -o pipefail 
+
+# Gets the /etc/os-release file from a worker node host OS
+# Sends the resulting filename to stdout
+get_node_os_release_file() {
+    os_release_file=${ARTIFACT_DIR}/etc-os-release
+    if [[ ! -s "${os_release_file}" ]]; then 
+	    worker_node=$(kubectl get nodes --selector='node-role.kubernetes.io/worker' -ojsonpath='{.items[].metadata.name}')
+
+	    oc debug node/${worker_node} \
+            --quiet \
+            -- cat /host/etc/os-release > ${os_release_file}
+    fi
+
+    echo ${os_release_file}
+}
+
+
+# Get running RHCOS version. Assumes all nodes are running the same version.
+# TODO check RT kernel version
+get_node_rhcos_version() {
+    os_release_file=$(get_node_os_release_file)
+    rhcos_version=$(cat ${os_release_file} \
+            | grep "OSTREE_VERSION" \
+            | cut -d= -f2 \
+            | tr -d \'\")
+
+    echo ${rhcos_version}
+}
+
+# Get RHEL version from RHCOS. This is the RHEL version which the current RHCOS release is based on.
+get_node_rhel_version() {
+    os_release_file=$(get_node_os_release_file)
+    rhel_version=$(cat ${os_release_file} \
+            | grep "RHEL_VERSION" \
+            | cut -d= -f2 \
+            | tr -d \'\")
+
+    echo ${rhel_version}
+}
+
+# Check if driver-toolkit imagestream is available
+test_imagestream() {
+    oc get imagestream/driver-toolkit -n openshift -o yaml > ${ARTIFACT_DIR}/driver-toolkit-imagestream.yaml
+}
+
+# Check for latest and RHCOS tags
+test_imagestream_tags() {
+    rhcos_version=$(get_node_rhcos_version)
+    echo "INFO: Node RHCOS version: ${rhcos_version}"
+
+    oc get imagestream/driver-toolkit -n openshift -o json | jq ".spec.tags[].name"
+    
+    image_latest=$(oc get imagestream/driver-toolkit -n openshift -o json \
+    	| jq ".spec.tags[] | select(.name == \"latest\") | .from.name")
+    echo "INFO: Image from latest tag: ${image_latest}"
+        
+    image_rhcos_tag=$(oc get imagestream/driver-toolkit -n openshift -o json \
+    	| jq ".spec.tags[] | select(.name == \"${rhcos_version}\") | .from.name")
+    echo "INFO: Image from RHCOS tag: ${image_rhcos_tag}"
+
+    if [[ ${image_latest} == "" ]]; then
+	    echo "ERROR: driver-toolkit latest tag is empty string"
+	    exit 1
+    fi
+
+    if [[ ${image_rhcos_tag} == "" ]]; then
+	    echo "ERROR: driver-toolkit RHCOS version tag is empty string"
+	    exit 1
+    fi
+    
+    if [[ ${image_rhcos_tag} != ${image_latest} ]]; then
+	    echo "ERROR: driver-toolkit latest and RHCOS version tags mismatch (${image_rhos_tag} != ${image_latest})"
+	    exit 1
+    fi
+}
+
+# Gets the /etc/driver-toolkit-release.json file from driver-toolkit
+# Sends the resulting filename to stdout
+get_driver_toolkit_release_file(){
+    driver_toolkit_release=${ARTIFACT_DIR}/driver-toolkit-release.json
+
+    if [[ ! -s "${driver_toolkit_release}" ]]; then 
+	    oc debug --image-stream="openshift/driver-toolkit:latest" \
+		    --quiet \
+		    -- cat /etc/driver-toolkit-release.json \
+		    > ${driver_toolkit_release}
+    fi
+
+    echo ${driver_toolkit_release}
+}
+
+# Check that driver-toolkit contains the right kernel version
+test_kernel_version() {
+    node_kernel=$(oc get nodes -ojsonpath='{.items[].status.nodeInfo.kernelVersion}')
+    echo "INFO: Node kernel: ${node_kernel}"
+
+    dtk_release_file=$(get_driver_toolkit_release_file)
+
+    dtk_kernel=$(cat ${dtk_release_file} | jq -r .KERNEL_VERSION)
+    echo "INFO: driver-toolkit kernel: ${dtk_kernel}"
+    
+    if [[ ${dtk_kernel} !=  ${node_kernel} ]]; then
+	    echo "ERROR: driver-toolkit and node kernel version mismatch: (${dtk_kernel} !=  ${node_kernel})"
+	    exit 1
+    fi
+}
+
+#Check that driver-toolkit RHEL_VERSION flag is set correctly.
+test_rhel_version() {
+    node_rhel_version=$(get_node_rhel_version)
+    echo "INFO: node RHEL version: ${node_rhel_version}"
+
+    dtk_release_file=$(get_driver_toolkit_release_file)
+
+    dtk_rhel_version=$(cat ${dtk_release_file} | jq -r .RHEL_VERSION)
+    echo "INFO: driver-toolkit RHEL version: ${dtk_rhel_version}"
+    
+    if [[ ${dtk_rhel_version} !=  ${node_rhel_version} ]]; then
+	    echo "ERROR: driver-toolkit and node RHEL version mismatch: ${dtk_rhel_version} !=  ${node_rhel_version})"
+	    exit 1
+    fi
+}
+
+list_kernel_packages() {
+    # Check that DTK contains all the packages
+    oc debug --image-stream="openshift/driver-toolkit:latest" \
+            --quiet \
+            -- dnf list installed | grep kernel
+}
+
+set_artifact_dir() {
+	if [ -z "${ARTIFACT_DIR:-}" ]; then
+		export ARTIFACT_DIR="/tmp/ci-artifacts_$(date +%Y%m%d%H%M%S)"
+		mkdir -p "$ARTIFACT_DIR"
+		echo "Using ARTIFACT_DIR=$ARTIFACT_DIR as default artifacts directory."
+	else
+		echo "Using ARTIFACT_DIR=$ARTIFACT_DIR."
+	fi
+}
+
+echo "#### Driver Toolkit e2e test ####"
+set_artifact_dir
+
+echo
+echo "## TEST: Checking imagestream/driver-toolkit ##"
+test_imagestream
+
+echo
+echo "## TEST: Checking that driver-toolkit/imagestream latest and RHCOS tag are matching and non-empty ##"
+test_imagestream_tags
+
+echo
+echo "## TEST: Checking that RHEL version in driver-toolkit matches the node ##"
+test_rhel_version
+
+echo
+echo "## TEST: Checking that kernel version in driver-toolkit matches the node ##"
+test_kernel_version
+
+echo
+echo "## INFO: Listing kernel packages in driver-toolkit image ##"
+list_kernel_packages


### PR DESCRIPTION
This PR adds an e2e test for the driver-toolkit, intended to be run in the OpenShift CI.

Currently the test is quite simple:
- Verify that the ImageStream/driver-toolkit exists
- Verify that the ImageStream/driver-toolkit tags are there (latest and RHCOS version) and that they match
- Verify that the kernel version in the driver-toolkit image matches the kernel version on a worker node.

Planned extensions of this testing include:
- Verify that the driver-toolkit also contains the right version of the real time kernel packages
- Build the simple-kmod on top of the driver-toolkit

Thanks to @kpouget for some ideas I borrowed from the gpu-operator testing in openshift-psap/ci-artifacts.

/cc @qbarrand @yevgeny-shnaidman @kpouget 