### PR TITLE
Replace kubectl command with oc in e2e test

### DIFF
--- a/test/e2e
+++ b/test/e2e
@@ -7,7 +7,7 @@ set -eux -o pipefail
 get_node_os_release_file() {
     os_release_file=${ARTIFACT_DIR}/etc-os-release
     if [[ ! -s "${os_release_file}" ]]; then 
-	    worker_node=$(kubectl get nodes --selector='node-role.kubernetes.io/worker' -ojsonpath='{.items[].metadata.name}')
+	    worker_node=$(oc get nodes --selector='node-role.kubernetes.io/worker' -ojsonpath='{.items[].metadata.name}')
 
 	    oc debug node/${worker_node} \
             --quiet \


### PR DESCRIPTION
As seen in [this failed test](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_release/24001/rehearse-24001-periodic-ci-openshift-driver-toolkit-master-4.9-e2e-aws-driver-toolkit/1463962933389168640/artifacts/e2e-aws-driver-toolkit/test/build-log.txt), the kubectl command is not available in the ci environment.

This was only there in error. Should have been `oc`.

