### PR TITLE
Add members of Partner Accelerators to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,18 @@
 approvers:
   - dagrayvid
+  - bthurber
+  - pacevedom
+  - pmtk
+  - qbarrand
+  - yevgeny-shnaidman
+  - ybettan
 reviewers:
-  - courtneypacheco
-  - jmencak
-  - ArangoGutierrez
   - dagrayvid
   - kpouget
+  - bthurber
+  - pacevedom
+  - pmtk
+  - qbarrand
+  - ybettan
+  - yevgeny-shnaidman
 component: "Driver Toolkit"


### PR DESCRIPTION
Remove most PSAP team members from OWNERS and add members of the Partner Accelerators team.