### PR TITLE
Bug 2031854: Add e2e test to 4.9 branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,6 @@ PWD              ?= $(shell pwd)
 
 verify: 
 	cat ./Dockerfile
+
+test-e2e:
+	./test/e2e

--- a/test/e2e
+++ b/test/e2e
@@ -10,6 +10,7 @@ get_node_os_release_file() {
 	    worker_node=$(oc get nodes --selector='node-role.kubernetes.io/worker' -ojsonpath='{.items[].metadata.name}')
 
 	    oc debug node/${worker_node} \
+            -n default \
             --quiet \
             -- cat /host/etc/os-release > ${os_release_file}
     fi
@@ -84,6 +85,7 @@ get_driver_toolkit_release_file(){
 
     if [[ ! -s "${driver_toolkit_release}" ]]; then 
 	    oc debug --image-stream="openshift/driver-toolkit:latest" \
+		    -n openshift \
 		    --quiet \
 		    -- cat /etc/driver-toolkit-release.json \
 		    > ${driver_toolkit_release}
@@ -127,6 +129,7 @@ test_rhel_version() {
 list_kernel_packages() {
     # Check that DTK contains all the packages
     oc debug --image-stream="openshift/driver-toolkit:latest" \
+	    -n openshift \
             --quiet \
             -- dnf list installed | grep kernel
 }

--- a/test/e2e
+++ b/test/e2e
@@ -7,7 +7,7 @@ set -eux -o pipefail
 get_node_os_release_file() {
     os_release_file=${ARTIFACT_DIR}/etc-os-release
     if [[ ! -s "${os_release_file}" ]]; then 
-	    worker_node=$(kubectl get nodes --selector='node-role.kubernetes.io/worker' -ojsonpath='{.items[].metadata.name}')
+	    worker_node=$(oc get nodes --selector='node-role.kubernetes.io/worker' -ojsonpath='{.items[].metadata.name}')
 
 	    oc debug node/${worker_node} \
             --quiet \

--- a/test/e2e
+++ b/test/e2e
@@ -1,12 +1,12 @@
 #! /bin/bash
 
-set -eux -o pipefail 
+set -eux -o pipefail
 
 # Gets the /etc/os-release file from a worker node host OS
 # Sends the resulting filename to stdout
 get_node_os_release_file() {
     os_release_file=${ARTIFACT_DIR}/etc-os-release
-    if [[ ! -s "${os_release_file}" ]]; then 
+    if [[ ! -s "${os_release_file}" ]]; then
 	    worker_node=$(oc get nodes --selector='node-role.kubernetes.io/worker' -ojsonpath='{.items[].metadata.name}')
 
 	    oc debug node/${worker_node} \
@@ -53,13 +53,15 @@ test_imagestream_tags() {
     echo "INFO: Node RHCOS version: ${rhcos_version}"
 
     oc get imagestream/driver-toolkit -n openshift -o json | jq ".spec.tags[].name"
-    
+
     image_latest=$(oc get imagestream/driver-toolkit -n openshift -o json \
-    	| jq ".spec.tags[] | select(.name == \"latest\") | .from.name")
+    	               | jq -r ".spec.tags[] | select(.name == \"latest\") | .from.name")
     echo "INFO: Image from latest tag: ${image_latest}"
-        
+
+    echo "$image_latest" > ${ARTIFACT_DIR}/latest_image.address
+
     image_rhcos_tag=$(oc get imagestream/driver-toolkit -n openshift -o json \
-    	| jq ".spec.tags[] | select(.name == \"${rhcos_version}\") | .from.name")
+    	                  | jq  -r ".spec.tags[] | select(.name == \"${rhcos_version}\") | .from.name")
     echo "INFO: Image from RHCOS tag: ${image_rhcos_tag}"
 
     if [[ ${image_latest} == "" ]]; then
@@ -71,7 +73,7 @@ test_imagestream_tags() {
 	    echo "ERROR: driver-toolkit RHCOS version tag is empty string"
 	    exit 1
     fi
-    
+
     if [[ ${image_rhcos_tag} != ${image_latest} ]]; then
 	    echo "ERROR: driver-toolkit latest and RHCOS version tags mismatch (${image_rhos_tag} != ${image_latest})"
 	    exit 1
@@ -83,7 +85,7 @@ test_imagestream_tags() {
 get_driver_toolkit_release_file(){
     driver_toolkit_release=${ARTIFACT_DIR}/driver-toolkit-release.json
 
-    if [[ ! -s "${driver_toolkit_release}" ]]; then 
+    if [[ ! -s "${driver_toolkit_release}" ]]; then
 	    oc debug --image-stream="openshift/driver-toolkit:latest" \
 		    -n openshift \
 		    --quiet \
@@ -96,6 +98,8 @@ get_driver_toolkit_release_file(){
 
 # Check that driver-toolkit contains the right kernel version
 test_kernel_version() {
+    oc get nodes -oyaml > ${ARTIFACT_DIR}/nodes.yaml
+
     node_kernel=$(oc get nodes -ojsonpath='{.items[].status.nodeInfo.kernelVersion}')
     echo "INFO: Node kernel: ${node_kernel}"
 
@@ -103,7 +107,10 @@ test_kernel_version() {
 
     dtk_kernel=$(cat ${dtk_release_file} | jq -r .KERNEL_VERSION)
     echo "INFO: driver-toolkit kernel: ${dtk_kernel}"
-    
+
+    echo "${dtk_kernel}" > ${ARTIFACT_DIR}/dtk-kernel.version
+    echo "${node_kernel}" > ${ARTIFACT_DIR}/node-kernel.version
+
     if [[ ${dtk_kernel} !=  ${node_kernel} ]]; then
 	    echo "ERROR: driver-toolkit and node kernel version mismatch: (${dtk_kernel} !=  ${node_kernel})"
 	    exit 1
@@ -119,7 +126,10 @@ test_rhel_version() {
 
     dtk_rhel_version=$(cat ${dtk_release_file} | jq -r .RHEL_VERSION)
     echo "INFO: driver-toolkit RHEL version: ${dtk_rhel_version}"
-    
+
+    echo "${dtk_rhel_version}" > ${ARTIFACT_DIR}/dtk-rhel.version
+    echo "${node_rhel_version}" > ${ARTIFACT_DIR}/node-rhel.version
+
     if [[ ${dtk_rhel_version} !=  ${node_rhel_version} ]]; then
 	    echo "ERROR: driver-toolkit and node RHEL version mismatch: ${dtk_rhel_version} !=  ${node_rhel_version})"
 	    exit 1
@@ -129,9 +139,25 @@ test_rhel_version() {
 list_kernel_packages() {
     # Check that DTK contains all the packages
     oc debug --image-stream="openshift/driver-toolkit:latest" \
-	    -n openshift \
-            --quiet \
-            -- dnf list installed | grep kernel
+	     -n openshift \
+             --quiet \
+             -- dnf list installed \
+        | grep kernel \
+        | tee ${ARTIFACT_DIR}/dnf-list-installed-kernel
+}
+
+get_dtk_image_info() {
+    oc debug --image-stream="openshift/driver-toolkit:latest" \
+             -n openshift \
+             --quiet \
+             -- bash -c 'echo "$SOURCE_GIT_URL/commit/$SOURCE_GIT_COMMIT"' \
+            > ${ARTIFACT_DIR}/git_commit
+
+    oc debug --image-stream="openshift/driver-toolkit:latest" \
+	     -n openshift \
+             --quiet \
+             -- env \
+             > ${ARTIFACT_DIR}/dtk_image_env
 }
 
 set_artifact_dir() {
@@ -142,10 +168,17 @@ set_artifact_dir() {
 	else
 		echo "Using ARTIFACT_DIR=$ARTIFACT_DIR."
 	fi
+
+        oc version -o json \
+            | jq --raw-output '.openshiftVersion' \
+                 > ${ARTIFACT_DIR}/ocp.version # for display in ci-dashboard
+
+        oc get clusterversion/version -oyaml > ${ARTIFACT_DIR}/ocp_version.yaml
 }
 
 echo "#### Driver Toolkit e2e test ####"
 set_artifact_dir
+get_dtk_image_info
 
 echo
 echo "## TEST: Checking imagestream/driver-toolkit ##"

--- a/test/e2e
+++ b/test/e2e
@@ -1,0 +1,165 @@
+#! /bin/bash
+
+set -eux -o pipefail 
+
+# Gets the /etc/os-release file from a worker node host OS
+# Sends the resulting filename to stdout
+get_node_os_release_file() {
+    os_release_file=${ARTIFACT_DIR}/etc-os-release
+    if [[ ! -s "${os_release_file}" ]]; then 
+	    worker_node=$(kubectl get nodes --selector='node-role.kubernetes.io/worker' -ojsonpath='{.items[].metadata.name}')
+
+	    oc debug node/${worker_node} \
+            --quiet \
+            -- cat /host/etc/os-release > ${os_release_file}
+    fi
+
+    echo ${os_release_file}
+}
+
+
+# Get running RHCOS version. Assumes all nodes are running the same version.
+# TODO check RT kernel version
+get_node_rhcos_version() {
+    os_release_file=$(get_node_os_release_file)
+    rhcos_version=$(cat ${os_release_file} \
+            | grep "OSTREE_VERSION" \
+            | cut -d= -f2 \
+            | tr -d \'\")
+
+    echo ${rhcos_version}
+}
+
+# Get RHEL version from RHCOS. This is the RHEL version which the current RHCOS release is based on.
+get_node_rhel_version() {
+    os_release_file=$(get_node_os_release_file)
+    rhel_version=$(cat ${os_release_file} \
+            | grep "RHEL_VERSION" \
+            | cut -d= -f2 \
+            | tr -d \'\")
+
+    echo ${rhel_version}
+}
+
+# Check if driver-toolkit imagestream is available
+test_imagestream() {
+    oc get imagestream/driver-toolkit -n openshift -o yaml > ${ARTIFACT_DIR}/driver-toolkit-imagestream.yaml
+}
+
+# Check for latest and RHCOS tags
+test_imagestream_tags() {
+    rhcos_version=$(get_node_rhcos_version)
+    echo "INFO: Node RHCOS version: ${rhcos_version}"
+
+    oc get imagestream/driver-toolkit -n openshift -o json | jq ".spec.tags[].name"
+    
+    image_latest=$(oc get imagestream/driver-toolkit -n openshift -o json \
+    	| jq ".spec.tags[] | select(.name == \"latest\") | .from.name")
+    echo "INFO: Image from latest tag: ${image_latest}"
+        
+    image_rhcos_tag=$(oc get imagestream/driver-toolkit -n openshift -o json \
+    	| jq ".spec.tags[] | select(.name == \"${rhcos_version}\") | .from.name")
+    echo "INFO: Image from RHCOS tag: ${image_rhcos_tag}"
+
+    if [[ ${image_latest} == "" ]]; then
+	    echo "ERROR: driver-toolkit latest tag is empty string"
+	    exit 1
+    fi
+
+    if [[ ${image_rhcos_tag} == "" ]]; then
+	    echo "ERROR: driver-toolkit RHCOS version tag is empty string"
+	    exit 1
+    fi
+    
+    if [[ ${image_rhcos_tag} != ${image_latest} ]]; then
+	    echo "ERROR: driver-toolkit latest and RHCOS version tags mismatch (${image_rhos_tag} != ${image_latest})"
+	    exit 1
+    fi
+}
+
+# Gets the /etc/driver-toolkit-release.json file from driver-toolkit
+# Sends the resulting filename to stdout
+get_driver_toolkit_release_file(){
+    driver_toolkit_release=${ARTIFACT_DIR}/driver-toolkit-release.json
+
+    if [[ ! -s "${driver_toolkit_release}" ]]; then 
+	    oc debug --image-stream="openshift/driver-toolkit:latest" \
+		    --quiet \
+		    -- cat /etc/driver-toolkit-release.json \
+		    > ${driver_toolkit_release}
+    fi
+
+    echo ${driver_toolkit_release}
+}
+
+# Check that driver-toolkit contains the right kernel version
+test_kernel_version() {
+    node_kernel=$(oc get nodes -ojsonpath='{.items[].status.nodeInfo.kernelVersion}')
+    echo "INFO: Node kernel: ${node_kernel}"
+
+    dtk_release_file=$(get_driver_toolkit_release_file)
+
+    dtk_kernel=$(cat ${dtk_release_file} | jq -r .KERNEL_VERSION)
+    echo "INFO: driver-toolkit kernel: ${dtk_kernel}"
+    
+    if [[ ${dtk_kernel} !=  ${node_kernel} ]]; then
+	    echo "ERROR: driver-toolkit and node kernel version mismatch: (${dtk_kernel} !=  ${node_kernel})"
+	    exit 1
+    fi
+}
+
+#Check that driver-toolkit RHEL_VERSION flag is set correctly.
+test_rhel_version() {
+    node_rhel_version=$(get_node_rhel_version)
+    echo "INFO: node RHEL version: ${node_rhel_version}"
+
+    dtk_release_file=$(get_driver_toolkit_release_file)
+
+    dtk_rhel_version=$(cat ${dtk_release_file} | jq -r .RHEL_VERSION)
+    echo "INFO: driver-toolkit RHEL version: ${dtk_rhel_version}"
+    
+    if [[ ${dtk_rhel_version} !=  ${node_rhel_version} ]]; then
+	    echo "ERROR: driver-toolkit and node RHEL version mismatch: ${dtk_rhel_version} !=  ${node_rhel_version})"
+	    exit 1
+    fi
+}
+
+list_kernel_packages() {
+    # Check that DTK contains all the packages
+    oc debug --image-stream="openshift/driver-toolkit:latest" \
+            --quiet \
+            -- dnf list installed | grep kernel
+}
+
+set_artifact_dir() {
+	if [ -z "${ARTIFACT_DIR:-}" ]; then
+		export ARTIFACT_DIR="/tmp/ci-artifacts_$(date +%Y%m%d%H%M%S)"
+		mkdir -p "$ARTIFACT_DIR"
+		echo "Using ARTIFACT_DIR=$ARTIFACT_DIR as default artifacts directory."
+	else
+		echo "Using ARTIFACT_DIR=$ARTIFACT_DIR."
+	fi
+}
+
+echo "#### Driver Toolkit e2e test ####"
+set_artifact_dir
+
+echo
+echo "## TEST: Checking imagestream/driver-toolkit ##"
+test_imagestream
+
+echo
+echo "## TEST: Checking that driver-toolkit/imagestream latest and RHCOS tag are matching and non-empty ##"
+test_imagestream_tags
+
+echo
+echo "## TEST: Checking that RHEL version in driver-toolkit matches the node ##"
+test_rhel_version
+
+echo
+echo "## TEST: Checking that kernel version in driver-toolkit matches the node ##"
+test_kernel_version
+
+echo
+echo "## INFO: Listing kernel packages in driver-toolkit image ##"
+list_kernel_packages


### PR DESCRIPTION
In some recently published z-stream releases of OCP, the driver-toolkit image contained the wrong kernel package versions. One measure we can take to avoid this going forward is to run an e2e test script against each nightly build of OCP to confirm the correct package versions are being installed.

We have been running this test as a periodic, using the e2e test from the master branch. To simplify the ci-operator configs for the driver-toolkit tests when adding them as release informing jobs, we should backport the e2e test to each branch we are testing against. 