### PR TITLE
Updating README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,11 @@ The following steps require the image pull secret needed to perform an installat
 
 The image URL of the `driver-toolkit` corresponding to a certain release can be extracted from the release image using the `oc adm` command:
 ```bash
-$ oc adm release info 4.8.0 --image-for=driver-toolkit
+# For x86 image:
+$ oc adm release info quay.io/openshift-release-dev/ocp-release:4.8.0-x86_64 --image-for=driver-toolkit
+
+# For ARM image:
+$ oc adm release info quay.io/openshift-release-dev/ocp-release:4.8.0-aarch64 --image-for=driver-toolkit
 ```
 
 Example output:
@@ -101,9 +105,7 @@ spec:
 
       WORKDIR /build/
 
-      RUN yum -y install git make sudo gcc \
-      && yum clean all \
-      && rm -rf /var/cache/dnf
+      # In case additional packages are required, you need to manually add the yum repos to the container
 
       # Expecting kmod software version as an input to the build
       ARG KMODVER


### PR DESCRIPTION
The yum repos were removed from DTK by the ART team. In addition to the
technical reason for that, the logical reason is that DTK should already
include all the dependencies required for building an loading the
drivers (as this is the whole point of DTK to begging with), therefore,
there is no reason to install anything in the exampled described in the
documentation.

Also updated the way to get the driver-toolkit image for OCP release.
The short method can be interpreted differently on different
architectures  and the long version is more explicit.


Signed-off-by: Yoni Bettan <yonibettan@gmail.com>

---

We already have some consumers that are hitting this issue as the documentation show how to install packages although the yum repos where already removed from the image.
https://issues.redhat.com/browse/OCPBUGSM-42828