### PR TITLE
Removing the 'make buildprep' from README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,7 @@ spec:
       WORKDIR simple-kmod
 
       # Prep and build the module
-      RUN make buildprep KVER=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}"  kernel-core) KMODVER=${KMODVER} \
-      && make all       KVER=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}"  kernel-core) KMODVER=${KMODVER} \
+      RUN make all       KVER=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}"  kernel-core) KMODVER=${KMODVER} \
       && make install   KVER=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}"  kernel-core) KMODVER=${KMODVER}
 
       # Add the helper tools


### PR DESCRIPTION
This makefile target was removed from the simple-kmod makefile and is no
longer needed.

Signed-off-by: Yoni Bettan <yonibettan@gmail.com>

---

Was removed [here](https://github.com/openshift-psap/simple-kmod/pull/1).