### PR TITLE
Bug 2087026: Adding manifests/ inside DTK container image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,8 @@ RUN if [ $(arch) == "x86_64" ] || [ $(arch) == "aarch64" ]; then \
     && yum -y install openssl keyutils $ARCH_DEP_PKGS \
     && yum clean all
 
+COPY manifests /manifests
+
 LABEL io.k8s.description="driver-toolkit is a container with the kernel packages necessary for building driver containers for deploying kernel modules/drivers on OpenShift" \
       name="driver-toolkit" \
       io.openshift.release.operator=true \


### PR DESCRIPTION
ART is looking into the content of this dir in order to deploy
additional manifests with OCP.

This is needed in order to deploy DTK's imagestream to the cluster.

Signed-off-by: Yoni Bettan <yonibettan@gmail.com>

---

This PR follows up on https://github.com/openshift/driver-toolkit/pull/81 in order to bring back the imagestream that was accidentally removed in https://github.com/openshift/driver-toolkit/pull/79.