### PR TITLE
Bug 2087114: Add simple-procfs-kmod in modprobe example in README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,10 +191,10 @@ spec:
         lifecycle:
           postStart:
             exec:
-              command: ["modprobe", "-v", "simple-kmod"]
+              command: ["modprobe", "-v", "-a" , "simple-kmod", "simple-procfs-kmod"]
           preStop:
             exec:
-              command: ["modprobe", "-r", "simple-kmod"]
+              command: ["modprobe", "-r", "-a" , "simple-kmod", "simple-procfs-kmod"]
         securityContext:
           privileged: true
       nodeSelector:


### PR DESCRIPTION
README.md lacks the instructions for loading/unloading the additional module simple-procfs-kmod in example. Added to modprobe example.
