### PR TITLE
Bug 2035488: Updating the doc for multi-stage driver containers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ spec:
 
       FROM registry.redhat.io/ubi8/ubi-minimal
 
-      RUN microdnf -y install kmod
+      # better to copy it from builder rather than pulling it from the internet so it work also with disconnected envs
+      COPY --from=builder /usr/bin/kmod /usr/bin/
 
       COPY --from=builder /etc/driver-toolkit-release.json /etc/ # special-resource-operator is expecting that file
       COPY --from=builder /lib/modules/<kernel version>/* /lib/modules/<kernel version>/


### PR DESCRIPTION
In the last layer, instead of installing `kmod` using micro-dnf we will
now just copy `kmod` binary from the builder stage.

In a disconnected env, we wouldn't not be able to run micro-dnf commands
at build time.

Signed-off-by: Yoni Bettan <yonibettan@gmail.com>