### PR TITLE
[WIP] Updating DTK doc to use /opt/lib/modules for KMMO (SRO v2).

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,9 @@ spec:
 
       RUN microdnf -y install kmod
 
-      COPY --from=builder /etc/driver-toolkit-release.json /etc/ # special-resource-operator is expecting that file
-      COPY --from=builder /lib/modules/<kernel version>/* /lib/modules/<kernel version>/
+      # special-resource-operator is expecting that file
+      COPY --from=builder /etc/driver-toolkit-release.json /etc/
+      COPY --from=builder /lib/modules/<kernel version>/* /opt/lib/modules/<kernel version>/
   strategy:
     dockerStrategy:
       buildArgs:
@@ -191,14 +192,15 @@ spec:
         lifecycle:
           postStart:
             exec:
-              command: ["modprobe", "-v", "-a" , "simple-kmod", "simple-procfs-kmod"]
+              command: ["modprobe", "-b", "/opt/lib/modules/<kver>", "-v", "-a" , "simple-kmod", "simple-procfs-kmod"]
           preStop:
             exec:
-              command: ["modprobe", "-r", "-a" , "simple-kmod", "simple-procfs-kmod"]
+              command: ["modprobe", "-b", "/opt/lib/modules/<kver>", "-r", "-a" , "simple-kmod", "simple-procfs-kmod"]
         securityContext:
           privileged: true
       nodeSelector:
         node-role.kubernetes.io/worker: ""
+#FIXME:ybettan: mount /lib/modules/<kver> from the node for in-tree dependencies
 
 ```
 


### PR DESCRIPTION
Unlike SRO, when KMMO deploy a driver-container, it will mount
/lib/modules/<kernel version> from the node to the driver-container
filesystem overriding all previous files in of the driver-container at
/lib/modules/<kernel version>, therefore, in driver-containers, kernel
modules should be located in /opt/lib/modules/<kernel version> instead
in order to not be overwritten.

The reason that KMMO is mounting /lib/modules/<kernel version> of the
node to begin with is in order to be able to install in-tree
driver-containers which are dependencies of the out-of-tree
driver-container that it tries to instal.

[MGMT-10194](https://issues.redhat.com//browse/MGMT-10194)

Signed-off-by: Yoni Bettan <yonibettan@gmail.com>