### PR TITLE
Add kernel{,-rt} RPM labels to the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,3 +61,5 @@ RUN export INSTALLED_KERNEL=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}"  kerne
     export INSTALLED_RT_KERNEL=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}"  kernel-rt-core); \
     echo "{ \"KERNEL_VERSION\": \"${INSTALLED_KERNEL}\", \"RT_KERNEL_VERSION\": \"${INSTALLED_RT_KERNEL}\", \"RHEL_VERSION\": \"${RHEL_VERSION}\" }" > /etc/driver-toolkit-release.json
 
+LABEL com.coreos.rpm.kernel="${INSTALLED_VERSION}" \
+      com.coreos.rpm.kernel-rt="${INSTALLED_RT_VERSION}"


### PR DESCRIPTION
When building a driver container, what matters to me is the version of the kernel, not the version of RHCOS. The kernel lifecycle is longer than the RHCOS lifecycle, so this reduces the number of builds I need in my build matrix to stay compatible with the nodes.

This information is available in the image itself, in the `/etc/driver-toolkit-release.json` file, but reading it requires pulling the container image, hence consuming bandwidth and temporary storage, which are both expensive. With labels on the container image, it becomes a single API call to read the image manifest.

This change adds these labels, with the same names as on the RHCOS container image.

Signed-off-by: Fabien Dupont <fdupont@redhat.com>