### PR TITLE
Adding 'flex' and 'bison' to the driver-toolkit image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN export INSTALLED_KERNEL=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}"  kerne
 yum clean all
 
 # Additional packages that are needed for a subset (e.g DPDK) of driver-containers
-RUN yum -y install xz diffutils \
+RUN yum -y install xz diffutils flex bison \
     && yum clean all
     
 # Packages needed to build driver-containers


### PR DESCRIPTION
Those packages are needed in order to compile the kernel since 4.16.

In addition to that, some kernel-modules needs them as well in order to compile.

Signed-off-by: Yoni Bettan <yonibettan@gmail.com>

---

Fixes https://github.com/openshift/driver-toolkit/issues/89