### PR TITLE
Adjusting the documentation to refer to KMM instead of SRO.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The Driver Toolkit also has several tools which are commonly needed to build and
 ##  Purpose
 Prior to the Driver Toolkit's existence, you could install kernel packages in a pod or build config on OpenShift using [entitled builds](https://www.openshift.com/blog/how-to-use-entitled-image-builds-to-build-drivercontainers-with-ubi-on-openshift "entitled builds") or by installing from the kernel RPMs in the hosts `machine-os-content`. The Driver Toolkit simplifies the process by removing the entitlement step, and avoids the privileged operation of accessing the machine-os-content in a pod. The Driver Toolkit can also be used by partners who have access to pre-released OpenShift versions to prebuild driver-containers for their hardware devices for future OpenShift releases.
 
-The Driver Toolkit is also used by the [Special Resource Operator (SRO)](https://github.com/openshift-psap/special-resource-operator "Special Resource Operator (SRO)"), which is currently available as a community Operator on OperatorHub. SRO supports out-of-tree and third-party kernel drivers and the support software for the underlying operating system. Users can create _recipes_ for SRO to build and deploy a driver container, as well as support software like a device plug-in, or metrics. Recipes can include a build config to build a driver container based on the Driver Toolkit, or SRO can deploy a prebuilt driver container.
+The Driver Toolkit is also used by the [Kernel Module Management (KMM)](https://github.com/rh-ecosystem-edge/kernel-module-management), which is currently available as a community Operator on OperatorHub. KMM supports out-of-tree and third-party kernel drivers and the support software for the underlying operating system. Users can create _modules_ for KMM to build and deploy a driver container, as well as support software like a device plug-in, or metrics. Modules can include a build config to build a driver container based on the Driver Toolkit, or KMM can deploy a prebuilt driver container.
 
 ## Pulling the image
 ### How to get the image from the Red Hat Ecosystem Catalog
@@ -114,7 +114,7 @@ spec:
       RUN for link in /usr/bin/modprobe /usr/bin/rmmod; do \
           ln -s /usr/bin/kmod "$link"; done
 
-      # special-resource-operator is expecting that file 
+      # kernel-module-management (operator) is expecting that file
       COPY --from=builder /etc/driver-toolkit-release.json /etc/ 
       COPY --from=builder /lib/modules/<kernel version>/* /lib/modules/<kernel version>/
   strategy:


### PR DESCRIPTION
Signed-off-by: Yoni Bettan <yonibettan@gmail.com>