### PR TITLE
Add check-commit-counts script

### DIFF
--- a/ci/prow/check-commits-count
+++ b/ci/prow/check-commits-count
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+git remote add upstream https://github.com/openshift/driver-toolkit.git
+git fetch upstream
+
+commits_count=$(git rev-list --count HEAD ^upstream/master)
+# When Prow is testing a PR, it is creating a branch for it but then merges it
+# into the "master" branch for testing, therefore, we also get the "merge commit"
+# in addition to the original commit.
+if [[ ${commits_count} != 2 ]]; then
+    echo '
+    All PRs must contain a single commit.
+    Please refer to https://github.com/openshift/driver-toolkit/blob/master/CONTRIBUTING.md
+    '
+    exit 1
+fi


### PR DESCRIPTION
Add check-commit-counts script to use with ci-operator

in order to check that PRs have only one single commit.