### PR TITLE
Adding documentation regarding the driver-toolkit imagestream.

### DIFF
--- a/docs/driver_toolkit_imagestream.md
+++ b/docs/driver_toolkit_imagestream.md
@@ -1,0 +1,12 @@
+# Driver-toolkit imagestream
+
+In OCP, you will find the driver-toolkit imagestream that will contain a tag for each RHCOS version running in the cluster.
+
+The name of the imagestream is `driver-toolkit` in the `openshift` namespace.
+
+In order to generate such imagestream during the cluster installation, there are multiple parts that needs to be taken into consideration:
+
+* DTK: add an [templated imagestream](../manifests/01-openshift-imagestream.yaml) to the payload.
+* ART: adding that imagestream to the cluster deployment (templeted) by running `oc adm release new ...`.
+* OC: Owning the code for `oc adm release new …` which will scrape the [machine-os-content](https://github.com/openshift/machine-config-operator/blob/master/docs/OSUpgrades.md#os-updates).
+* MCO: owns the machine-os-content.


### PR DESCRIPTION
This imagestream, its complexity, and its moving part seems to be confusing a lot of people, therefore, having a single place in which we are documenting all the involved teams and moving parts is crucial for preventing breaking changes.

Signed-off-by: Yoni Bettan <yonibettan@gmail.com>