### PR TITLE
Adding rpm-build to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN yum -y install xz diffutils flex bison \
     && yum clean all
     
 # Packages needed to build driver-containers
-RUN yum -y install git make \
+RUN yum -y install git make rpm-build \
     && yum clean all
 
 # Packages needed to sign and run externally build kernel modules


### PR DESCRIPTION
rpmbuild in the DTK helps when having to rebuild source kernel module RPMs to match the RHCOS kernel version