### PR TITLE
Fixing `check-commits-count` to work on other branches than `master`.

### DIFF
--- a/ci/prow/check-commits-count
+++ b/ci/prow/check-commits-count
@@ -5,7 +5,8 @@ set -euxo pipefail
 git remote add upstream https://github.com/openshift/driver-toolkit.git
 git fetch upstream
 
-commits_count=$(git rev-list --count HEAD ^upstream/master)
+branch_name=$(git branch --show-current)
+commits_count=$(git rev-list --count HEAD ^upstream/${branch_name})
 # When Prow is testing a PR, it is creating a branch for it but then merges it
 # into the "master" branch for testing, therefore, we also get the "merge commit"
 # in addition to the original commit.


### PR DESCRIPTION
Signed-off-by: Yoni Bettan <yonibettan@gmail.com>