### PR TITLE
OCPBUGS-11119: Fixing the regexp used to get the correct GCC version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,11 +31,10 @@ RUN yum -y install elfutils-libelf-devel kmod binutils kabi-dw \
     
 # Find and install the GCC version used to compile the kernel
 # If it cannot be found (fails on some architecutres), install the default gcc
-RUN export INSTALLED_KERNEL=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}"  kernel-core) \
-&& GCC_VERSION=$(cat /lib/modules/${INSTALLED_KERNEL}/config | grep -Eo "Compiler: gcc \(GCC\) ([0-9\.]+)" | grep -Eo "([0-9\.]+)") \
-&& yum -y install gcc-${GCC_VERSION} \
-|| yum -y install gcc && \
-yum clean all
+RUN export INSTALLED_KERNEL=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}"  kernel-core) && \
+    GCC_VERSION=$(cat /lib/modules/${INSTALLED_KERNEL}/config | grep -Eo "gcc \(GCC\) ([0-9\.]+)" | grep -Eo "([0-9\.]+)") && \
+    yum -y install gcc-${GCC_VERSION} || yum -y install gcc && \
+    yum clean all
 
 # Additional packages that are needed for a subset (e.g DPDK) of driver-containers
 RUN yum -y install xz diffutils flex bison \


### PR DESCRIPTION
The string representing the GCC version has changed between RHEL 8.6 and RHEL 9.2.

In 8.6 it looks like:
```
$ cat /lib/modules/<kernel version>/config | grep gcc
Compiler: gcc (GCC) 8.5.0 20210514 (Red Hat 8.5.0-10) 
```

In 9.2 it looks lie:
```
$ cat /lib/modules/<kernel version>/config | grep gcc
CONFIG_CC_VERSION_TEXT="gcc (GCC) 11.3.1 20221121 (Red Hat 11.3.1-4)"
```

---

Basically I have just removed the word `Compiler` from the regexp. All the rest is just cosmetics.