### PR TITLE
MCO-392: Start using `rhel-coreos` image rather than `machine-os-content`

### DIFF
--- a/docs/driver_toolkit_imagestream.md
+++ b/docs/driver_toolkit_imagestream.md
@@ -8,5 +8,5 @@ In order to generate such imagestream during the cluster installation, there are
 
 * DTK: add an [templated imagestream](../manifests/01-openshift-imagestream.yaml) to the payload.
 * ART: adding that imagestream to the cluster deployment (templeted) by running `oc adm release new ...`.
-* OC: Owning the code for `oc adm release new …` which will scrape the [machine-os-content](https://github.com/openshift/machine-config-operator/blob/master/docs/OSUpgrades.md#os-updates).
-* MCO: owns the machine-os-content.
+* OC: Owning the code for `oc adm release new …` which will scrape the [rhel-coreos image](https://github.com/openshift/machine-config-operator/blob/master/docs/OSUpgrades.md#os-updates).
+* MCO: owns the `rhel-coreos` image.

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -6,7 +6,7 @@ spec:
     from:
       kind: DockerImage
       name: example.com/image-reference-placeholder:driver-toolkit
-  - name: machine-os-content
+  - name: rhel-coreos
     from:
       kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift:machine-os-content
+      name: example.com/image-reference-placeholder:rhel-coreos


### PR DESCRIPTION
The `machine-os-content` is deprecated and we'd like to stop shipping it entirely in the release payload. Point the DTK imagestream to the `rhel-coreos` image instead.

Closes: #101