### PR TITLE
Revert "Start using `rhel-coreos` image rather than `machine-os-content` (#135)"

### DIFF
--- a/docs/driver_toolkit_imagestream.md
+++ b/docs/driver_toolkit_imagestream.md
@@ -8,5 +8,5 @@ In order to generate such imagestream during the cluster installation, there are
 
 * DTK: add an [templated imagestream](../manifests/01-openshift-imagestream.yaml) to the payload.
 * ART: adding that imagestream to the cluster deployment (templeted) by running `oc adm release new ...`.
-* OC: Owning the code for `oc adm release new …` which will scrape the [rhel-coreos image](https://github.com/openshift/machine-config-operator/blob/master/docs/OSUpgrades.md#os-updates).
-* MCO: owns the `rhel-coreos` image.
+* OC: Owning the code for `oc adm release new …` which will scrape the [machine-os-content](https://github.com/openshift/machine-config-operator/blob/master/docs/OSUpgrades.md#os-updates).
+* MCO: owns the machine-os-content.

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -6,7 +6,7 @@ spec:
     from:
       kind: DockerImage
       name: example.com/image-reference-placeholder:driver-toolkit
-  - name: rhel-coreos
+  - name: machine-os-content
     from:
       kind: DockerImage
-      name: example.com/image-reference-placeholder:rhel-coreos
+      name: registry.svc.ci.openshift.org/openshift:machine-os-content


### PR DESCRIPTION
This reverts commit 86bbea7aadc5a6f6214c6d3bd95f40096725fee8.

We need to revert the openshift/os side of this because of remaining references to machine-os-content:

https://github.com/openshift/os/pull/1393

So we have to revert this too.