### PR TITLE
MGMT-16314: Remove kernel-core and kernel-modules packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,15 +9,11 @@ RUN echo ${RHEL_VERSION} > /etc/yum/vars/releasever \
 RUN dnf -y install \
     kernel-devel${KERNEL_VERSION:+-}${KERNEL_VERSION} \
     kernel-headers${KERNEL_VERSION:+-}${KERNEL_VERSION} \
-    kernel-modules${KERNEL_VERSION:+-}${KERNEL_VERSION} \
-    kernel-modules-extra${KERNEL_VERSION:+-}${KERNEL_VERSION}
 
 # real-time kernel packages
 RUN if [ $(arch) = x86_64 ]; then \
     dnf -y install \
     kernel-rt-devel${RT_KERNEL_VERSION:+-}${RT_KERNEL_VERSION} \
-    kernel-rt-modules${RT_KERNEL_VERSION:+-}${RT_KERNEL_VERSION} \
-    kernel-rt-modules-extra${RT_KERNEL_VERSION:+-}${RT_KERNEL_VERSION}; \
     fi
 
 RUN dnf -y install kernel-rpm-macros
@@ -53,6 +49,6 @@ LABEL io.k8s.description="driver-toolkit is a container with the kernel packages
 
 # Last layer for metadata for mapping the driver-toolkit to a specific kernel version
 RUN export INSTALLED_KERNEL=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}"  kernel-devel); \
-    export INSTALLED_RT_KERNEL=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}"  kernel-rt-core); \
+    export INSTALLED_RT_KERNEL=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}"  kernel-rt-devel); \
     echo "{ \"KERNEL_VERSION\": \"${INSTALLED_KERNEL}\", \"RT_KERNEL_VERSION\": \"${INSTALLED_RT_KERNEL}\", \"RHEL_VERSION\": \"${RHEL_VERSION}\" }" > /etc/driver-toolkit-release.json
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN dnf -y install elfutils-libelf-devel kmod binutils kabi-dw glibc
 # If it cannot be found (fails on some architectures), install the default gcc
 RUN export INSTALLED_KERNEL=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}"  kernel-devel) && \
     GCC_VERSION=$(cat /lib/modules/${INSTALLED_KERNEL}/config | grep -Eo "gcc \(GCC\) ([0-9\.]+)" | grep -Eo "([0-9\.]+)") && \
-    dnf -y install gcc-${GCC_VERSION} || dnf -y install gcc
+    dnf -y install gcc-${GCC_VERSION} gcc-c++-${GCC_VERSION} || dnf -y install gcc gcc-c++
 
 # Additional packages that are needed for a subset (e.g DPDK) of driver-containers
 RUN dnf -y install xz diffutils flex bison


### PR DESCRIPTION
To build kernel modules, only the `kernel-headers` and `kernel-devel` packages are needed. This change removes the `kernel-core`, `kernel-modules` and `kernel-modules-extra` packages from the image to reduce its size by ~110 MB.

Depends-on: https://github.com/openshift/driver-toolkit/pull/137

Signed-off-by: Fabien Dupont <fdupont@redhat.com>
