### PR TITLE
MGMT-16701: Add support for 64k pages with ARM64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,16 @@ RUN if [ $(arch) = x86_64 ]; then \
     kernel-rt-modules-extra${RT_KERNEL_VERSION:+-}${RT_KERNEL_VERSION}; \
     fi
 
+# 64k-pages kernel packages for aarch64
+# Headers are not compiled, so there is no kernel-64k-headers packages,
+# and compilation will use the headers from kernel-headers
+RUN if [ $(arch) = aarch64 ]; then \
+    dnf -y install \
+    kernel-64k-devel${KERNEL_VERSION:+-}${KERNEL_VERSION} \
+    kernel-64k-modules${KERNEL_VERSION:+-}${KERNEL_VERSION} \
+    kernel-64k-modules-extra${KERNEL_VERSION:+-}${KERNEL_VERSION}; \
+    fi
+
 RUN dnf -y install kernel-rpm-macros
 
 # Additional packages that are mandatory for driver-containers


### PR DESCRIPTION
RHEL 9 and RHCOS for 4.15 are adding support for installing a 64k pages size ARM kernel at runtime, with the `kernelType: '64k-pages'` attribute in the MachineConfig specification. When applied, the kernel is switched to the `+64k` version, e.g. `5.14.0-284.41.1.el9_2.aarch64` becomes `5.14.0-284.41.1.el9_2.aarch64+64k`.

From a Driver Toolkit perspective, the user should be able to use a kernel version suffixed by `+64k` at build time. This is provided by the `kernel-64k` packages.

This change adds the relevant packages to the driver toolkit image when the architecture is `aarch64`.