### PR TITLE
IR-192: Add importMode and set it to PreserveOriginal to import the manifestlisted image

### DIFF
--- a/manifests/01-openshift-imagestream.yaml
+++ b/manifests/01-openshift-imagestream.yaml
@@ -13,12 +13,14 @@ spec:
   - name: latest
     importPolicy:
       scheduled: true
+      importMode: PreserveOriginal
     from:
       kind: DockerImage
       name: example.com/image-reference-placeholder:driver-toolkit
   - name: 0.0.1-snapshot-machine-os 
     importPolicy:
       scheduled: true
+      importMode: PreserveOriginal
     from:
       kind: DockerImage
       name: example.com/image-reference-placeholder:driver-toolkit


### PR DESCRIPTION
Similar to
https://github.com/openshift/cluster-samples-operator/pull/482, we want CVO managed imagestreams to have the importMode as preserveOriginal so that it imports the manifestlisted image with all arches so that it works on a multi-arch compute cluster