### PR TITLE
OCPBUGS-33699: Adding the `+` char to the RT kernel version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,6 @@ LABEL io.k8s.description="driver-toolkit is a container with the kernel packages
 
 # Last layer for metadata for mapping the driver-toolkit to a specific kernel version
 RUN export INSTALLED_KERNEL=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}"  kernel-devel); \
-    export INSTALLED_RT_KERNEL=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}"  kernel-rt-core); \
+    export INSTALLED_RT_KERNEL=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}+rt"  kernel-rt-core); \
     echo "{ \"KERNEL_VERSION\": \"${INSTALLED_KERNEL}\", \"RT_KERNEL_VERSION\": \"${INSTALLED_RT_KERNEL}\", \"RHEL_VERSION\": \"$(</etc/yum/vars/releasever)\" }" > /etc/driver-toolkit-release.json
 


### PR DESCRIPTION
Since 4.16, the kernel and the rt-kernel are coming rom the same repository, therefore, they need to be differentiated explicitly in order to match the new kernel version format for the RT kernel.

Example for the new RT kernel version format:
```
5.14.0-427.18.1.el9_4.x86_64+rt
```

---

/cc @yevgeny-shnaidman @cdvultur 