### PR TITLE
MGMT-19342: Adding the `kernel-devel-matched` package.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN [ "${RHEL_VERSION}" == "" ] && source /etc/os-release && RHEL_VERSION=${VERS
 # kernel packages needed to build drivers / kmods 
 RUN dnf -y install \
     kernel-devel${KERNEL_VERSION:+-}${KERNEL_VERSION} \
+    kernel-devel-matched${KERNEL_VERSION:+-}${KERNEL_VERSION} \
     kernel-headers${KERNEL_VERSION:+-}${KERNEL_VERSION} \
     kernel-modules${KERNEL_VERSION:+-}${KERNEL_VERSION} \
     kernel-modules-extra${KERNEL_VERSION:+-}${KERNEL_VERSION}


### PR DESCRIPTION
Summary: Meta package to install matching core and devel packages for a given kernel.

AMD, needs this package in order to build their kmods.