### PR TITLE
MGMT-19671: Using `jq` instead of `yq` in the `e2e` job.

### DIFF
--- a/test/e2e
+++ b/test/e2e
@@ -134,7 +134,7 @@ test_kernel_version() {
 
 # Check that driver-toolkit contains the right kernel-rt version
 test_kernel_rt_version() {
-    ocp_version=$(oc get clusterversion -o yaml | yq '.items[0].status.desired.version')
+    ocp_version=$(oc get clusterversion -o json | jq -r '.items[0].status.desired.version')
 
     rhel_coreos_extensions_image=$(oc adm release info quay.io/openshift-release-dev/ocp-release:${ocp_version}-x86_64 \
         --image-for=rhel-coreos-extensions)


### PR DESCRIPTION
`yq` is not installed in the image that runs the job on nightly builds. It is installed on the pre-merge job though, therefore, it wasn't catch during PR creation.

This commit should fix the issue.

---

/assign @yevgeny-shnaidman @TomerNewman 
Nightly builds are currently failing because the `yq` tool doesn't exist in the test image.