### PR TITLE
MGMT-19688: Pulling the DTK image from the CI registry instead of quay.io.

### DIFF
--- a/test/e2e
+++ b/test/e2e
@@ -136,7 +136,7 @@ test_kernel_version() {
 test_kernel_rt_version() {
     ocp_version=$(oc get clusterversion -o json | jq -r '.items[0].status.desired.version')
 
-    rhel_coreos_extensions_image=$(oc adm release info quay.io/openshift-release-dev/ocp-release:${ocp_version}-x86_64 \
+    rhel_coreos_extensions_image=$(oc adm release info registry.ci.openshift.org/ocp/release:${ocp_version} \
         --image-for=rhel-coreos-extensions)
 
     node_kernel_rt=$(podman run -it --rm ${rhel_coreos_extensions_image} ls /usr/share/rpm-ostree/extensions/ | \


### PR DESCRIPTION
This job is running on OCP nightly builds and the OCP payload for those versions aren't available in quay.io but instead they are in `registry.ci.openshift.org`.

---

/assign @yevgeny-shnaidman @TomerNewman 
