### PR TITLE
MGMT-19747: Getting the kernel version from the `kernel-rt-core-*` file.

### DIFF
--- a/test/e2e
+++ b/test/e2e
@@ -145,7 +145,7 @@ test_kernel_rt_version() {
         --image=${rhel_coreos_extensions_image} \
         --restart=Never \
         --command -- ls /usr/share/rpm-ostree/extensions/ | \
-            grep -oP "kernel-rt-\K[0-9]+(\.[0-9]+)*-[0-9]+(\.[0-9]+)*\.[a-z0-9_]+(\.[a-z0-9_]+)*(?=\.rpm)")
+            grep -oP "kernel-rt-core-\K[0-9]+(\.[0-9]+)*-[0-9]+(\.[0-9]+)*\.[a-z0-9_]+(\.[a-z0-9_]+)*(?=\.rpm)")
     echo "INFO: Node kernel-rt: ${node_kernel_rt}"
 
     dtk_release_file=$(get_driver_toolkit_release_file)


### PR DESCRIPTION
OCP 4.19 has recently bumped its RHEL version from 9.4 to 9.6. With this change, seems like the
`/usr/share/rpm-ostree/extensions/kernel-rt-<version>...` file is gone so the test has been adjusted to get the version from the `/usr/share/rpm-ostree/extensions/kernel-rt-core-<version>...` file instead.

---

/assign @TomerNewman @yevgeny-shnaidman 

In the recent containers:
```
root gpu-operator (main) $ oc adm release info registry.ci.openshift.org/ocp/release:4.19.0-0.nightly-2025-01-19-034009 --image-for=rhel-coreos-extensions
quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:297ff1d0d9e4ecd2f48ba50cfe07e88f5bb3f6379c27786fba5768f63fa9b000

root gpu-operator (main) $ podman run -it --rm quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:297ff1d0d9e4ecd2f48ba50cfe07e88f5bb3f6379c27786fba5768f63fa9b000 ls -1 /usr/share/rpm-ostree/extensions/ | grep kernel-rt
kernel-rt-core-5.14.0-552.el9.x86_64.rpm
kernel-rt-devel-5.14.0-552.el9.x86_64.rpm
kernel-rt-kvm-5.14.0-552.el9.x86_64.rpm
kernel-rt-modules-5.14.0-552.el9.x86_64.rpm
kernel-rt-modules-core-5.14.0-552.el9.x86_64.rpm
kernel-rt-modules-extra-5.14.0-552.el9.x86_64.rpm
```

In container based on RHEL 9.4:
```
root gpu-operator (main) $ oc adm release info registry.ci.openshift.org/ocp/release:4.19.0-0.nightly-2025-01-15-060507 --image-for=rhel-coreos-extensions
quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:7b6a994d9cd627551bc6866841ce15428c65b6a9b49e20e0da501b17014da359

root gpu-operator (main) $ podman run -it --rm quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:7b6a994d9cd627551bc6866841ce15428c65b6a9b49e20e0da501b17014da359 ls -l /usr/share/rpm-ostree/extensions/ | grep kernel-rt
-rw-r--r--. 1 root root  3813281 Jan 13 18:49 kernel-rt-5.14.0-427.51.1.el9_4.x86_64.rpm
-rw-r--r--. 1 root root 19312353 Jan 13 18:49 kernel-rt-core-5.14.0-427.51.1.el9_4.x86_64.rpm
-rw-r--r--. 1 root root 20380805 Jan 13 18:49 kernel-rt-devel-5.14.0-427.51.1.el9_4.x86_64.rpm
-rw-r--r--. 1 root root  4518229 Jan 13 18:49 kernel-rt-kvm-5.14.0-427.51.1.el9_4.x86_64.rpm
-rw-r--r--. 1 root root 38912981 Jan 13 18:49 kernel-rt-modules-5.14.0-427.51.1.el9_4.x86_64.rpm
-rw-r--r--. 1 root root 32060453 Jan 13 18:49 kernel-rt-modules-core-5.14.0-427.51.1.el9_4.x86_64.rpm
-rw-r--r--. 1 root root  4283873 Jan 13 18:49 kernel-rt-modules-extra-5.14.0-427.51.1.el9_4.x86_64.rpm
```