### PR TITLE
MGMT-20889: Use VERSION_ID for RHEL minor version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG KERNEL_VERSION=''
 ARG RT_KERNEL_VERSION=''
 ARG RHEL_VERSION=''
 # If RHEL_VERSION is empty, we infer it from the /etc/os-release file. This is used by OKD as we always want the latest one. 
-RUN [ "${RHEL_VERSION}" == "" ] && source /etc/os-release && RHEL_VERSION=${VERSION}; echo ${RHEL_VERSION} > /etc/yum/vars/releasever \
+RUN [ "${RHEL_VERSION}" == "" ] && source /etc/os-release && RHEL_VERSION=${VERSION_ID}; echo ${RHEL_VERSION} > /etc/dnf/vars/releasever \
     && dnf config-manager --best --setopt=install_weak_deps=False --save
 
 # kernel packages needed to build drivers / kmods 
@@ -71,5 +71,5 @@ LABEL io.k8s.description="driver-toolkit is a container with the kernel packages
 # Last layer for metadata for mapping the driver-toolkit to a specific kernel version
 RUN export INSTALLED_KERNEL=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}"  kernel-devel); \
     export INSTALLED_RT_KERNEL=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}+rt"  kernel-rt-core); \
-    echo "{ \"KERNEL_VERSION\": \"${INSTALLED_KERNEL}\", \"RT_KERNEL_VERSION\": \"${INSTALLED_RT_KERNEL}\", \"RHEL_VERSION\": \"$(</etc/yum/vars/releasever)\" }" > /etc/driver-toolkit-release.json
+    echo "{ \"KERNEL_VERSION\": \"${INSTALLED_KERNEL}\", \"RT_KERNEL_VERSION\": \"${INSTALLED_RT_KERNEL}\", \"RHEL_VERSION\": \"$(</etc/dnf/vars/releasever)\" }" > /etc/driver-toolkit-release.json
 


### PR DESCRIPTION
The VERSION variable in `/etc/os-release` contains also the name of the major version. In the RHEL 9 case, it adds ` (Plow)` to the `releasever` variable. We don't know how DNF is using it, but it creates a risk.

This pull request modifies the environment variable to use the `VERSION_ID`, which contains only the RHEL minor version.

It also modifies the DNF variables folder to `/etc/dnf/vars` to comply with DNF configuration and remove a _legacy_ setting.
    
Signed-off-by: Fabien Dupont <fdupont@redhat.com>