### PR TITLE
OCPBUGS-78533: Support ubi minimal base image

### DIFF
--- a/test/e2e
+++ b/test/e2e
@@ -187,9 +187,9 @@ list_kernel_packages() {
     oc debug --image-stream="openshift/driver-toolkit:latest" \
 	     -n $TEST_NS \
              --quiet \
-             -- dnf list installed \
+             -- rpm -qa \
         | grep kernel \
-        | tee ${ARTIFACT_DIR}/dnf-list-installed-kernel
+        | tee ${ARTIFACT_DIR}/rpm-list-installed-kernel
 }
 
 get_dtk_image_info() {


### PR DESCRIPTION
UBI minimal does not have dnf/yum. It only has
microdnf and ART's emulation layer does not support "list".