### PR TITLE
OCPBUGS-69851: Adding support for payload multiple-stream.

### DIFF
--- a/Dockerfile.rhel10
+++ b/Dockerfile.rhel10
@@ -59,16 +59,13 @@ RUN if [ $(arch) == "x86_64" ] || [ $(arch) == "aarch64" ]; then \
 RUN dnf clean all && rm -rf /var/cache/dnf/*
 
 COPY manifests/01-openshift-imagestream.yaml /manifests/01-openshift-imagestream.yaml
-COPY manifests/image-references /manifests/image-references
-
-ARG TAGS=''
-RUN if echo "${TAGS:-}" | grep -q scos > /dev/null 2>&1; then sed -i 's/rhel-coreos/stream-coreos/g' /manifests/*; fi
+COPY manifests/image-references-rhel10 /manifests/image-references
 
 LABEL io.k8s.description="driver-toolkit is a container with the kernel packages necessary for building driver containers for deploying kernel modules/drivers on OpenShift" \
       name="driver-toolkit" \
       io.openshift.release.operator=true \
       version="0.1" \
-      io.openshift.os.streamclass=rhel-9 \
+      io.openshift.os.streamclass=rhel-10 \
       kernel-version=${KERNEL_VERSION} \
       kernel-rt-version=${RT_KERNEL_VERSION}
 

--- a/manifests/image-references-rhel10
+++ b/manifests/image-references-rhel10
@@ -1,0 +1,12 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+spec:
+  tags:
+  - name: driver-toolkit
+    from:
+      kind: DockerImage
+      name: example.com/image-reference-placeholder:driver-toolkit
+  - name: rhel-coreos-10
+    from:
+      kind: DockerImage
+      name: example.com/image-reference-placeholder:rhel-coreos-10


### PR DESCRIPTION
The multiple-stream effort will contain multiple images considered as `machine-os` in the payload as well as multiple `driver-toolkit` images.

This commit is adding some labels to the container such as the `rhel-stream` and `kernel-version`.

In addition it adds a reference to the `rhel-coreos-10` image in order to specify to the payload that DTK depends on the `rhel-coreos-10` image.

---

/assign @jlebon 
/cc @dustymabe @sdodson @travier @joepvd 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RHEL 10–based driver-toolkit images with kernel dev/tools, modules, and real-time kernel support for x86_64 and aarch64.

* **Infrastructure**
  * Build/runtime metadata now exposes stream class, kernel version, real-time kernel version, and resolved RHEL release.
  * Image manifests refined into explicit image entries for clearer image management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->