### PR TITLE
test/e2e: always use correct release pull spec in RELEASE_IMAGE_LATEST

### DIFF
--- a/test/e2e
+++ b/test/e2e
@@ -135,9 +135,7 @@ test_kernel_version() {
 
 # Check that driver-toolkit contains the right kernel-rt version
 test_kernel_rt_version() {
-    ocp_version=$(oc get clusterversion -o json | jq -r '.items[0].status.desired.version')
-
-    rhel_coreos_extensions_image=$(oc adm release info registry.ci.openshift.org/ocp/release:${ocp_version} \
+    rhel_coreos_extensions_image=$(oc adm release info "${RELEASE_IMAGE_LATEST}" \
         --registry-config "${CLUSTER_PROFILE_DIR}/pull-secret" \
         --image-for=rhel-coreos-extensions)
 


### PR DESCRIPTION
with 5.0 the release repo changed; ci-operator should always supply the correct one in this var.