### PR TITLE
OCPBUGS-69851: Adding driver-toolkit-10 as a new payload component for RHEL 10.

### DIFF
--- a/Dockerfile.rhel10
+++ b/Dockerfile.rhel10
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
+FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
 ARG KERNEL_VERSION=''
 ARG RT_KERNEL_VERSION=''
 ARG RHEL_VERSION=''
@@ -58,11 +58,11 @@ RUN if [ $(arch) == "x86_64" ] || [ $(arch) == "aarch64" ]; then \
 
 RUN dnf clean all && rm -rf /var/cache/dnf/*
 
-COPY manifests/01-openshift-imagestream.yaml /manifests/01-openshift-imagestream.yaml
+COPY manifests/01-openshift-imagestream-rhel10.yaml /manifests/01-openshift-imagestream.yaml
 COPY manifests/image-references-rhel10 /manifests/image-references
 
 LABEL io.k8s.description="driver-toolkit is a container with the kernel packages necessary for building driver containers for deploying kernel modules/drivers on OpenShift" \
-      name="driver-toolkit" \
+      name="driver-toolkit-10" \
       io.openshift.release.operator=true \
       version="0.1" \
       io.openshift.os.streamclass=rhel-10 \

--- a/manifests/01-openshift-imagestream-rhel10.yaml
+++ b/manifests/01-openshift-imagestream-rhel10.yaml
@@ -10,17 +10,17 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
 spec:
   tags:
-  - name: latest
+  - name: latest-rhel-10
     importPolicy:
       scheduled: true
       importMode: PreserveOriginal
     from:
       kind: DockerImage
-      name: example.com/image-reference-placeholder:driver-toolkit
+      name: example.com/image-reference-placeholder:driver-toolkit-10
   - name: 0.0.1-snapshot-machine-os
     importPolicy:
       scheduled: true
       importMode: PreserveOriginal
     from:
       kind: DockerImage
-      name: example.com/image-reference-placeholder:driver-toolkit
+      name: example.com/image-reference-placeholder:driver-toolkit-10

--- a/manifests/image-references-rhel10
+++ b/manifests/image-references-rhel10
@@ -2,10 +2,10 @@ kind: ImageStream
 apiVersion: image.openshift.io/v1
 spec:
   tags:
-  - name: driver-toolkit
+  - name: driver-toolkit-10
     from:
       kind: DockerImage
-      name: example.com/image-reference-placeholder:driver-toolkit
+      name: example.com/image-reference-placeholder:driver-toolkit-10
   - name: rhel-coreos-10
     from:
       kind: DockerImage


### PR DESCRIPTION
---

/assign @TomerNewman @yevgeny-shnaidman 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated the container base image to a newer OpenShift/RHEL 10–compatible version.
  * Updated OpenShift image stream configuration to use RHEL 10–specific tags (`driver-toolkit-10`) and Docker image references.
* **New Features**
  * Added an OpenShift `ImageStream` for the `openshift` namespace to support RHEL 10 tags (`latest-rhel-10` and `0.0.1-snapshot-machine-os`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->