### PR TITLE
OCPBUGS-69851: Updating Dockerfile.rhel10 base image from base-rhel9 to base-rhel10.

### DIFF
--- a/Dockerfile.rhel10
+++ b/Dockerfile.rhel10
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
+FROM registry.ci.openshift.org/ocp/5.0:base-rhel10
 ARG KERNEL_VERSION=''
 ARG RT_KERNEL_VERSION=''
 ARG RHEL_VERSION=''


### PR DESCRIPTION
The base-rhel10 image is now available in the CI registry (registry.ci.openshift.org/ocp/5.0:base-rhel10),
so we can use the proper RHEL 10 base image for the DTK-10 build.

---

/assign @yevgeny-shnaidman @TomerNewman 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container build base image to a newer RHEL 10 image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->