### PR TITLE
OCPBUGS-69851: Fix e2e test failure caused by TTY carriage returns in oc run output

### DIFF
--- a/test/e2e
+++ b/test/e2e
@@ -43,7 +43,7 @@ get_rhcos_os_release_file() {
             --registry-config "${CLUSTER_PROFILE_DIR}/pull-secret" \
             --image-for=${RHCOS_IMAGE_NAME})
 
-        oc run -it rhcos-os-release -n ${TEST_NS} \
+        oc run -i rhcos-os-release -n ${TEST_NS} \
             --rm \
             --image=${rhcos_image} \
             --restart=Never \
@@ -137,7 +137,7 @@ test_kernel_version() {
         --registry-config "${CLUSTER_PROFILE_DIR}/pull-secret" \
         --image-for=${RHCOS_IMAGE_NAME})
 
-    rhcos_kernel=$(oc run -it rhcos-kernel -n ${TEST_NS} \
+    rhcos_kernel=$(oc run -i rhcos-kernel -n ${TEST_NS} \
         --rm \
         --image=${rhcos_image} \
         --restart=Never \
@@ -164,7 +164,7 @@ test_kernel_rt_version() {
         --registry-config "${CLUSTER_PROFILE_DIR}/pull-secret" \
         --image-for=${RHCOS_EXTENSIONS_IMAGE_NAME})
 
-    rhcos_kernel_rt=$(oc run -it rhcos-extensions -n ${TEST_NS} \
+    rhcos_kernel_rt=$(oc run -i rhcos-extensions -n ${TEST_NS} \
         --rm \
         --image=${rhcos_extensions_image} \
         --restart=Never \


### PR DESCRIPTION
The -t flag on oc run allocates a TTY which converts \n to \r\n. This caused the RHCOS version extracted from /etc/os-release to contain a trailing \r, breaking the jq imagestream tag lookup.

---

/assign @TomerNewman @yevgeny-shnaidman 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of end-to-end validation by removing unnecessary TTY allocation from image inspection commands.
  * This helps prevent command execution issues when retrieving operating system and kernel version details during automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->