### PR TITLE
MGMT-24788: Fix pod deletion message contaminating RHCOS kernel version string

### DIFF
--- a/test/e2e
+++ b/test/e2e
@@ -141,7 +141,8 @@ test_kernel_version() {
         --rm \
         --image=${rhcos_image} \
         --restart=Never \
-        --command -- rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}" kernel-core)
+        --command -- rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}\n" kernel-core \
+        | head -1)
     echo "INFO: RHCOS kernel: ${rhcos_kernel}"
 
     dtk_release_file=$(get_driver_toolkit_release_file)


### PR DESCRIPTION
The `oc run --rm` command prints `pod "..." deleted` to stdout. Since the rpm --qf format had no trailing newline, this message was appended directly to the kernel version (e.g. "5.14.0-687.21.1.el9_8.x86_64pod ..."), causing kernel version comparison to always fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end kernel version checking so command output is handled more consistently.
  * Made the version probe less sensitive to extra output by using only the first result line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->